### PR TITLE
crm_channel_delete calls correct function

### DIFF
--- a/modules/channel/crm_channel.entity.inc
+++ b/modules/channel/crm_channel.entity.inc
@@ -75,7 +75,7 @@ function crm_channel_load_multiple($ids) {
  * @param $ids
  */
 function crm_channel_delete($id) {
-  crm_channel_delete(array($id));
+  crm_channel_delete_multiple(array($id));
 }
 
 /**


### PR DESCRIPTION
With this change `crm_channel_delete` will call `crm_channel_delete_multiple` and not it self.
